### PR TITLE
Fix gamemode map lookup

### DIFF
--- a/internal/services/kfserver/utils.go
+++ b/internal/services/kfserver/utils.go
@@ -30,7 +30,7 @@ func GetGameModeMapPrefix(gamemode string) string {
 		"objective": "KFO-",
 		"toymaster": "TOY-",
 	}
-	return modes[gamemode]
+	return modes[strings.ToLower(gamemode)]
 }
 
 func GetGameModeMaplistName(gamemode string) string {
@@ -39,7 +39,7 @@ func GetGameModeMaplistName(gamemode string) string {
 		"objective": "KFStoryGame.KFOMapList",
 		"toymaster": "KFCharPuppets.TOYMapList",
 	}
-	return mlist[gamemode]
+	return mlist[strings.ToLower(gamemode)]
 }
 
 func GetSeasonalSpecimenType() string {

--- a/internal/settings/defaults.go
+++ b/internal/settings/defaults.go
@@ -6,7 +6,7 @@ const (
 	DefaultGamePort                  = 7707
 	DefaultWebAdminPort              = 8075
 	DefaultGameSpyPort               = 7717
-	DefaultGameMode                  = "KFmod.KFGameType"
+	DefaultGameMode                  = "survival"
 	DefaultStartupMap                = "KF-BioticsLab"
 	DefaultGameDifficulty            = "hard"
 	DefaultGameLength                = "medium"


### PR DESCRIPTION
The default game mode was set to `KFmod.KFGameType` which is not mapped in functions `GetGameModeMapPrefix` and `GetGameModeMaplistName`, thus ending up in the server not starting with the default setting left untouched.

I could have changed the maps in function to use `KFmod.KFGameType` but it felt more correct to change the default value of game mode to `survival` as it's done for game length and difficulty. I also change the map lookup to always performed it in lower case so that if we got `Survival` as raw value of the config, the lookup will still work. This is what is done in other places of the code base.