### PR TITLE
Download KFPatcher if enabled and missing files

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,8 +23,8 @@ func BuildRootCommand() *cobra.Command {
 
 	var configFile, serverName, shortName, gameMode, startupMap, gameDifficulty, gameLength,
 		password, adminName, adminMail, adminPassword, motd, specimenType, mutators,
-		serverMutators, redirectURL, mapList, allTradersMessage, logLevel, logFilePath,
-		logFileFormat string
+		serverMutators, redirectURL, mapList, allTradersMessage, kfunflectURL, kfpatcherURL,
+		logLevel, logFilePath, logFileFormat string
 
 	var gamePort, webadminPort, gamespyPort, maxPlayers, maxSpectators, region,
 		mapVoteRepeatLimit, logMaxSize, logMaxBackups, logMaxAge int
@@ -85,6 +85,8 @@ func BuildRootCommand() *cobra.Command {
 		"buyeverywhere":       {&enableBuyEverywhere, "(KFPatcher) allow players to shop whenever", settings.DefaultKFPBuyEverywhere},
 		"alltraders":          {&enableAllTraders, "(KFPatcher) make all trader's spots accessible", settings.DefaultKFPEnableAllTraders},
 		"alltraders-message":  {&allTradersMessage, "(KFPatcher) All traders screen message", settings.DefaultKFPAllTradersMessage},
+		"kfunflect-url":       {&kfunflectURL, "(KFPatcher) KFUnflect URL", settings.DefaultKFUnflectURL},
+		"kfpatcher-url":       {&kfpatcherURL, "(KFPatcher) arhchive URL", settings.DefaultKFPatcherURL},
 		"log-to-file":         {&enableFileLogging, "enable file logging", settings.DefaultLogToFile},
 		"log-level":           {&logLevel, "log level (info, debug, warn, error)", settings.DefaultLogLevel},
 		"log-file":            {&logFilePath, "log file path", settings.DefaultLogFile},
@@ -188,6 +190,8 @@ func registerArguments(sett *settings.KFDSLSettings) {
 	sett.KFPBuyEverywhere = arguments.NewArgument[bool](viper.GetBool("buyeverywhere"), "KFP Buy Everywhere", nil, arguments.FormatBool, false)
 	sett.KFPEnableAllTraders = arguments.NewArgument[bool](viper.GetBool("alltraders"), "KFP All Traders", nil, arguments.FormatBool, false)
 	sett.KFPAllTradersMessage = arguments.NewArgument[string](viper.GetString("alltraders-message"), "KFP All Traders Msg", nil, nil, false)
+	sett.KFPatcherURL = arguments.NewArgument[string](viper.GetString("kfpatcher-url"), "KFPatcher URL", arguments.ParseURL, nil, false)
+	sett.KFUnflectURL = arguments.NewArgument[string](viper.GetString("kfunflect-url"), "KFUnflect URL", arguments.ParseURL, nil, false)
 	sett.LogToFile = arguments.NewArgument[bool](viper.GetBool("log-to-file"), "Log to File", nil, arguments.FormatBool, false)
 	sett.LogLevel = arguments.NewArgument[string](viper.GetString("log-level"), "Log Level", arguments.ParseLogLevel, nil, false)
 	sett.LogFile = arguments.NewArgument[string](viper.GetString("log-file"), "Log File", nil, nil, false)

--- a/internal/settings/defaults.go
+++ b/internal/settings/defaults.go
@@ -62,3 +62,8 @@ const (
 	DefaultInternalSpecimenType   = "ET_None"
 	DefaultMaxInternetClientRate  = 10000
 )
+
+const (
+	DefaultKFUnflectURL = "https://github.com/InsultingPros/KFUnflect/releases/download/1.0.0/KFUnflect.u"
+	DefaultKFPatcherURL = "https://github.com/InsultingPros/KFPatcher/releases/download/1.4.0/KFPatcher.zip"
+)

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -53,6 +53,8 @@ type KFDSLSettings struct {
 	KFPBuyEverywhere     *arguments.Argument[bool]    // KFPatcher: Allows opening the buy menu anywhere (untested)
 	KFPEnableAllTraders  *arguments.Argument[bool]    // KFPatcher: All of the trader's spots are accessible after each wave
 	KFPAllTradersMessage *arguments.Argument[string]  // KFPatcher: All traders open message
+	KFPatcherURL         *arguments.Argument[string]  // KFPatcher: archive URL
+	KFUnflectURL         *arguments.Argument[string]  // KFPatcher: KFUnflect URL
 	LogToFile            *arguments.Argument[bool]    // Enable file logging
 	LogLevel             *arguments.Argument[string]  // Log level (info, debug, warn, error)
 	LogFile              *arguments.Argument[string]  // Log file path

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -1,9 +1,13 @@
 package utils
 
 import (
+	"archive/zip"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 func CopyFile(srcPath, destPath string) error {
@@ -24,6 +28,18 @@ func CopyFile(srcPath, destPath string) error {
 		return err
 	}
 	return destinationFile.Sync()
+}
+
+func MoveFile(srcPath, dstPath string) error {
+	if err := CopyFile(srcPath, dstPath); err != nil {
+		return fmt.Errorf("failed to copy file: %w", err)
+	}
+
+	if err := os.Remove(srcPath); err != nil {
+		return fmt.Errorf("failed to remove source file: %w", err)
+	}
+
+	return nil
 }
 
 func CopyAndReplaceFile(srcPath, destPath string) error {
@@ -59,4 +75,79 @@ func CopyAndReplaceFile(srcPath, destPath string) error {
 func FileExists(filename string) bool {
 	_, err := os.Stat(filename)
 	return err == nil || !os.IsNotExist(err)
+}
+
+func DownloadFile(url string) (string, error) {
+	filename := filepath.Join(os.TempDir(), url[strings.LastIndex(url, "/")+1:])
+
+	out, err := os.Create(filename)
+	if err != nil {
+		return filename, err
+	}
+	defer out.Close()
+
+	response, err := http.Get(url)
+	if err != nil {
+		return filename, err
+	}
+	defer response.Body.Close()
+
+	_, err = io.Copy(out, response.Body)
+
+	return filename, err
+}
+
+func UnzipFile(source, destination string) error {
+	r, err := zip.OpenReader(source)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	os.MkdirAll(destination, os.ModeDir)
+
+	extractAndWriteFile := func(f *zip.File) error {
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer rc.Close()
+
+		path := filepath.Join(destination, f.Name)
+
+		// Check for ZipSlip (directory traversal)
+		if !strings.HasPrefix(path, filepath.Clean(destination)+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal file path: %s", path)
+		}
+
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(path, f.Mode())
+		} else {
+			os.MkdirAll(filepath.Dir(path), f.Mode())
+			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			_, err = io.Copy(f, rc)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, f := range r.File {
+		err := extractAndWriteFile(f)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := os.Remove(source); err != nil {
+		return fmt.Errorf("failed to remove source file: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR introduces 2 new settings corresponding to URLs to download the KFPatcher archive and the KFUnflect file. Files are only download if they are not present in the `System` directory of the gameserver. This aims to be indempotent but it won't be if files are updated. We might want to add checksums checks in the logic to make sure that the downloaded files and the local files match. However this means that we would need to download the files at every start.